### PR TITLE
ci: automatically generate javadoc

### DIFF
--- a/.ci/push_javadoc.sh
+++ b/.ci/push_javadoc.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+git config --global user.email 'hubot@users.noreply.github.com'
+git config --global user.name 'Azure CI'
+
+GIT_REV="$(git rev-parse --short HEAD)"
+./gradlew javadoc 2> /dev/null
+[ -z "${BUILD_SOURCESDIRECTORY}" ] && BUILD_SOURCESDIRECTORY="$(pwd)"
+pushd /tmp/
+git clone https://github.com/CMPUT301F19T19/CMPUT301F19T19.github.io pages
+cd -- pages
+rm -rf javadoc
+cp -ar "${BUILD_SOURCESDIRECTORY}/app/build/javadoc" .
+git add javadoc
+git commit -m "Automatically generated javadoc for ${GIT_REV}"
+git push https://${PUSH_CRED}@github.com/CMPUT301F19T19/CMPUT301F19T19.github.io.git
+popd

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,16 @@ android {
     }
 }
 
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+    destinationDir = file("./build/javadoc/")
+    exclude '**/BuildConfig.java'
+    exclude '**/R.java'
+    failOnError false
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,11 +6,13 @@ pool:
 
 steps:
 - task: DownloadSecureFile@1
+  displayName: Download Token
   name: gmsToken
   inputs:
     secureFile: 'google-services.json'
 - bash: mv $(gmsToken.secureFilePath) '$(Build.SourcesDirectory)/app/'
 - task: Gradle@2
+  displayName: Build the Gradle project
   inputs:
     workingDirectory: ''
     gradleWrapperFile: 'gradlew'
@@ -19,11 +21,18 @@ steps:
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'assembleDebug'
 - task: CopyFiles@2
+  displayName: Copy APK files
   inputs:
     sourceFolder: '$(Build.SourcesDirectory)/app/build/outputs/apk/'
     contents: '**/*.apk'
     TargetFolder: '$(Build.ArtifactStagingDirectory)'
 - task: PublishBuildArtifacts@1
+  displayName: Upload APK files to artifact storage
   inputs:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: apk
+- bash: ./.ci/push_javadoc.sh
+  displayName: Generate Javadoc
+  env:
+    PUSH_CRED: $(PUSH_CRED)
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
Automatically generates `javadoc` and upload the documents to https://cmput301f19t19.github.io/javadoc/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cmput301f19t19/legendary-fiesta/28)
<!-- Reviewable:end -->
